### PR TITLE
Bad line fix

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -461,7 +461,21 @@ cdef class TextReader:
                 raise ValueError("Only length-1 comment characters supported")
             self.parser.commentchar = <char>ord(comment)
 
-        self.parser.on_bad_lines = on_bad_lines
+        if isinstance(on_bad_lines, str):
+            if on_bad_lines == 'error':
+                c_on_bad_lines = ERROR
+            elif on_bad_lines == 'warn':
+                c_on_bad_lines = WARN
+            elif on_bad_lines == 'skip':
+                c_on_bad_lines = SKIP
+            # Note: can add 'skip_with_log' here later when we work on logging
+            else:
+                raise ValueError(f"Invalid value for on_bad_lines: {on_bad_lines}")
+        else:
+            # If it's not a string, assume it's already an integer/enum constant (like ERROR)
+            c_on_bad_lines = on_bad_lines
+
+        self.parser.on_bad_lines = c_on_bad_lines
 
         self.skiprows = skiprows
         if skiprows is not None:

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1099,6 +1099,16 @@ cdef class TextReader:
                         stacklevel=find_stack_level()
                     )
 
+            # Re-convert failed columns to their target dtype now that bad rows
+            # have been removed. All remaining values should be convertible.
+            for col_idx, target_dtype in failed_columns_dtypes.items():
+                try:
+                    results[col_idx] = np.array(results[col_idx]).astype(target_dtype)
+                except (ValueError, TypeError, OverflowError):
+                    # If conversion still fails, keep as string (shouldn't happen
+                    # if _identify_bad_rows worked correctly, but be defensive)
+                    pass
+
         self.parser_start += end - start
 
         return results

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -937,6 +937,11 @@ cdef class TextReader:
             int64_t num_cols
             dict results
             bint is_default_dict_dtype
+            set bad_rows
+            dict failed_columns_dtypes
+
+        bad_rows = set()
+        failed_columns_dtypes = {}
 
         start = self.parser_start
 
@@ -1009,6 +1014,26 @@ cdef class TextReader:
                 col_res, na_count = self._convert_tokens(
                     i, start, end, name, na_filter, na_hashset,
                     na_fset, col_dtype)
+            except (ValueError, TypeError, OverflowError) as e:
+                # GH#63168: Handle dtype conversion failures based on on_bad_lines
+                if self.parser.on_bad_lines == SKIP or self.parser.on_bad_lines == WARN:
+                    # Fall back to string conversion
+                    col_res, na_count = self._string_convert(
+                        i, start, end, na_filter, na_hashset)
+
+                    # Track this column's intended dtype for later bad row detection
+                    if col_dtype is not None:
+                        failed_columns_dtypes[i] = col_dtype
+
+                    if self.parser.on_bad_lines == WARN:
+                        warnings.warn(
+                            f"Could not convert column {name} to dtype {col_dtype}: "
+                            f"{e}. Rows with unconvertible values will be skipped.",
+                            ParserWarning,
+                            stacklevel=find_stack_level()
+                        )
+                else:
+                    raise
             finally:
                 # gh-21353
                 #
@@ -1033,6 +1058,32 @@ cdef class TextReader:
                 raise ParserError(f"Unable to parse column {i}")
 
             results[i] = col_res
+
+        # GH#63168: Filter out bad rows if on_bad_lines is SKIP or WARN
+        if failed_columns_dtypes:
+            # Identify bad rows from columns that failed dtype conversion
+            for col_idx, target_dtype in failed_columns_dtypes.items():
+                col_values = results[col_idx]
+                bad_row_indices = _identify_bad_rows(col_values, target_dtype)
+                bad_rows.update(bad_row_indices)
+
+            if bad_rows:
+                num_rows = end - start
+                good_mask = np.ones(num_rows, dtype=np.bool_)
+                for bad_idx in bad_rows:
+                    good_mask[bad_idx] = False
+
+                # Filter all columns to keep only good rows
+                for col_idx in results:
+                    results[col_idx] = results[col_idx][good_mask]
+
+                if self.parser.on_bad_lines == WARN:
+                    warnings.warn(
+                        f"Skipped {len(bad_rows)} line(s) due to dtype "
+                        f"conversion errors.",
+                        ParserWarning,
+                        stacklevel=find_stack_level()
+                    )
 
         self.parser_start += end - start
 
@@ -1402,6 +1453,51 @@ STR_NA_VALUES = {
     "None",
 }
 _NA_VALUES = _ensure_encoded(list(STR_NA_VALUES))
+
+
+def _identify_bad_rows(values, dtype):
+    """
+    Identify row indices where values cannot be converted to the target dtype.
+
+    GH#63168: Used to find rows that should be skipped when on_bad_lines='skip'.
+
+    Parameters
+    ----------
+    values : ndarray
+        Array of values (typically strings/objects) to check.
+    dtype : numpy dtype
+        Target dtype to check conversion against.
+
+    Returns
+    -------
+    set
+        Set of row indices (0-based) that cannot be converted.
+    """
+    bad_indices = set()
+
+    for idx in range(len(values)):
+        val = values[idx]
+
+        # Skip None/NaN values - they're handled separately
+        if val is None:
+            continue
+        if isinstance(val, float) and np.isnan(val):
+            continue
+        if isinstance(val, str) and val.strip() == "":
+            continue
+
+        try:
+            if dtype.kind in "iu":  # integer types
+                int(val)
+            elif dtype.kind == "f":  # float types
+                float(val)
+            elif dtype.kind == "b":  # boolean
+                # Boolean conversion is more complex, skip for now
+                pass
+        except (ValueError, TypeError):
+            bad_indices.add(idx)
+
+    return bad_indices
 
 
 def _maybe_upcast(

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1492,7 +1492,7 @@ def _identify_bad_rows(values, dtype):
             elif dtype.kind == "f":  # float types
                 float(val)
             elif dtype.kind == "b":  # boolean
-                # Boolean conversion is more complex, skip for now
+                # Complex pass it until we fix again
                 pass
         except (ValueError, TypeError):
             bad_indices.add(idx)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1015,13 +1015,13 @@ cdef class TextReader:
                     i, start, end, name, na_filter, na_hashset,
                     na_fset, col_dtype)
             except (ValueError, TypeError, OverflowError) as e:
-                # GH#63168: Handle dtype conversion failures based on on_bad_lines
+                # Handle dtype conversion failure based on on_bad_lines
                 if self.parser.on_bad_lines == SKIP or self.parser.on_bad_lines == WARN:
                     # Fall back to string conversion
                     col_res, na_count = self._string_convert(
                         i, start, end, na_filter, na_hashset)
 
-                    # Track this column's intended dtype for later bad row detection
+                    # Track the columns intended dtype for bad row detection lateron
                     if col_dtype is not None:
                         failed_columns_dtypes[i] = col_dtype
 
@@ -1059,7 +1059,7 @@ cdef class TextReader:
 
             results[i] = col_res
 
-        # GH#63168: Filter out bad rows if on_bad_lines is SKIP or WARN
+        # Filters out the bad rows if on_bad_lines is skipped or warned
         if failed_columns_dtypes:
             # Identify bad rows from columns that failed dtype conversion
             for col_idx, target_dtype in failed_columns_dtypes.items():
@@ -1457,16 +1457,16 @@ _NA_VALUES = _ensure_encoded(list(STR_NA_VALUES))
 
 def _identify_bad_rows(values, dtype):
     """
-    Identify row indices where values cannot be converted to the target dtype.
+    Identify the row indices when values cannot be converted to the intended target
 
-    GH#63168: Used to find rows that should be skipped when on_bad_lines='skip'.
+    This can be used to find rows that should be skipped when on_bad_lines='skip'
 
     Parameters
     ----------
     values : ndarray
-        Array of values (typically strings/objects) to check.
+        Array of values to check
     dtype : numpy dtype
-        Target dtype to check conversion against.
+        Target dtype to check conversion against
 
     Returns
     -------

--- a/pandas/tests/io/parser/common/test_read_errors.py
+++ b/pandas/tests/io/parser/common/test_read_errors.py
@@ -313,3 +313,111 @@ a,b
     ):
         result = parser.read_csv(StringIO(data), on_bad_lines="warn")
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "on_bad_lines,should_warn",
+    [
+        ("skip", False),
+        ("warn", True),
+    ],
+)
+def test_on_bad_lines_dtype_conversion_skip(c_parser_only, on_bad_lines, should_warn):
+    # GH#63168 - on_bad_lines should handle dtype conversion failures
+    parser = c_parser_only
+    data = "col1,col2,col3\n1,2,3\na,4,5\n4,5,6"
+
+    if should_warn:
+        with tm.assert_produces_warning(
+            ParserWarning,
+            match="Could not convert column|Skipped .* line",
+            check_stacklevel=False,
+        ):
+            result = parser.read_csv(
+                StringIO(data),
+                dtype={"col1": int, "col2": int, "col3": int},
+                on_bad_lines=on_bad_lines,
+            )
+    else:
+        result = parser.read_csv(
+            StringIO(data),
+            dtype={"col1": int, "col2": int, "col3": int},
+            on_bad_lines=on_bad_lines,
+        )
+
+    # Row with 'a' cannot convert to int, should be skipped
+    expected = DataFrame({"col1": [1, 4], "col2": [2, 5], "col3": [3, 6]})
+    tm.assert_frame_equal(result, expected)
+
+
+def test_on_bad_lines_dtype_conversion_error(c_parser_only):
+    # GH#63168 - on_bad_lines='error' should raise on dtype conversion failure
+    parser = c_parser_only
+    data = "col1,col2\n1,2\na,3"
+
+    with pytest.raises(ValueError, match="invalid literal for int"):
+        parser.read_csv(
+            StringIO(data),
+            dtype={"col1": int, "col2": int},
+            on_bad_lines="error",
+        )
+
+
+def test_on_bad_lines_dtype_float_conversion(c_parser_only):
+    # GH#63168 - Float dtype with non-numeric values
+    parser = c_parser_only
+    data = "a,b\n1.5,2.5\nfoo,3.5\n4.5,5.5"
+
+    result = parser.read_csv(
+        StringIO(data),
+        dtype={"a": float, "b": float},
+        on_bad_lines="skip",
+    )
+
+    expected = DataFrame({"a": [1.5, 4.5], "b": [2.5, 5.5]})
+    tm.assert_frame_equal(result, expected)
+
+
+def test_on_bad_lines_dtype_partial_columns(c_parser_only):
+    # GH#63168 - Only some columns have dtype specified
+    parser = c_parser_only
+    data = "a,b,c\n1,hello,3\nfoo,world,6\n4,test,9"
+
+    result = parser.read_csv(
+        StringIO(data),
+        dtype={"a": int, "c": int},
+        on_bad_lines="skip",
+    )
+
+    expected = DataFrame({"a": [1, 4], "b": ["hello", "test"], "c": [3, 9]})
+    tm.assert_frame_equal(result, expected)
+
+
+def test_on_bad_lines_dtype_mixed_errors(c_parser_only):
+    # GH#63168 - Mix of structural errors (wrong field count) and dtype errors
+    parser = c_parser_only
+    data = "a,b,c\n1,2,3\nwrong_field_count\nfoo,4,5\n6,7,8"
+
+    result = parser.read_csv(
+        StringIO(data),
+        dtype={"a": int, "b": int, "c": int},
+        on_bad_lines="skip",
+    )
+
+    expected = DataFrame({"a": [1, 6], "b": [2, 7], "c": [3, 8]})
+    tm.assert_frame_equal(result, expected)
+
+
+def test_on_bad_lines_dtype_all_bad_rows(c_parser_only):
+    # GH#63168 - All data rows fail conversion
+    parser = c_parser_only
+    data = "a,b\nfoo,bar\nbaz,qux"
+
+    result = parser.read_csv(
+        StringIO(data),
+        dtype={"a": int, "b": int},
+        on_bad_lines="skip",
+    )
+
+    expected = DataFrame({"a": [], "b": []}).astype(int)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #1

## Summary
- Fixed `on_bad_lines="skip"` to handle dtype conversion failures
- Previously only handled wrong field count, now also skips rows that can't convert to specified dtype

## Changes
- Modified `pandas/_libs/parsers.pyx`
- Added exception handling in `_convert_column_data` method
- Added `_identify_bad_rows` helper function

## Test
`python
import pandas as pd
import io

csv_text = "column1,column2,column3\n1,2,3\nIAMAWRONGLINE\na,4,5"
buffer = io.StringIO(csv_text)

df = pd.read_csv(buffer, header=0, on_bad_lines="skip", dtype={"column1": int, "column2": int, "column3": int})
print(df)`

<img width="1010" height="252" alt="image" src="https://github.com/user-attachments/assets/9eec295c-ae18-4ec3-bd40-ab33708c8f2f" />


